### PR TITLE
Added type filtering to home page

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -41,7 +41,7 @@ export const getCity = (city: string) => {
 export const getAttractions = (
   longitude: number,
   latitude: number,
-  radius: number,
+  radius: number
 ) => {
   return googlePlacesAPI
     .post(
@@ -68,7 +68,6 @@ export const getAttractions = (
           "gift_shop",
           "department_store",
           "shopping_mall",
-          "market",
           "book_store",
           "athletic_field",
           "fitness_center",
@@ -90,8 +89,7 @@ export const getAttractions = (
           "hiking_area",
           "historical_landmark",
           "marina",
-          "movie_theater",
-        ],
+          "movie_theater"],
         maxResultCount: 20,
         locationRestriction: {
           circle: {
@@ -110,6 +108,39 @@ export const getAttractions = (
       throw err;
     });
 };
+
+export const getAttractionsWithType = (
+  longitude: number,
+  latitude: number,
+  radius: number,
+  type: Array<string> 
+) => {
+  return googlePlacesAPI
+    .post(
+      `/places:searchNearby`,
+      {
+        includedPrimaryTypes: type,
+        maxResultCount: 20,
+        locationRestriction: {
+          circle: {
+            center: {
+              latitude: latitude,
+              longitude: longitude,
+            },
+            radius: radius,
+          },
+        },
+      },
+      { headers: getAttractionsHeaders },
+    )
+    .catch((err) => {
+      console.error(err);
+      throw err;
+    });
+};
+
+
+
 
 export const getPhoto = (
   photoReference: string,
@@ -186,9 +217,10 @@ export const postBucketListItem = (
     })
   }
 
-  export const getSearchPlaces = (rectangle, text)=>{
+  export const getSearchPlaces = (rectangle, text, type)=>{
     return googlePlacesAPI.post(`/places:searchText`, {
       textQuery: `${text}`,
+      includedType: type,
      
       locationRestriction: {
         rectangle: rectangle

--- a/components/AttractionCard.tsx
+++ b/components/AttractionCard.tsx
@@ -99,7 +99,6 @@ else{
     <View style={styles.container}>
       <View style={styles.attractionTitle}>
         <View>
-          {" "}
           <ThemedText style={styles.titleText}>{attraction.displayName.text}</ThemedText>
         </View>
       </View>

--- a/components/AttractionFilter.tsx
+++ b/components/AttractionFilter.tsx
@@ -1,0 +1,61 @@
+import { View, Text, StyleSheet, CheckBox } from "react-native";
+import React from "react";
+import { ThemedText } from "./ThemedText";
+import { useEffect, useState } from "react";
+import { Dropdown } from "react-native-element-dropdown";
+
+export default function AttractionFilter({ type, setType }) {
+  const typesList = [
+    { label: "All", value: "All" },
+    { label: "Museums", value: "museum" },
+    { label: "Galleries", value: "art_gallery" },
+    { label: "Historical landmarks", value: "historical_landmark" },
+    { label: "Restaurants", value: "restaurant" },
+    { label: "Cafes", value: "cafe" },
+    { label: "Parks", value: "park" },
+    { label: "Theatres", value: "performing_arts_theater" },
+    { label: "Cinemas", value: "movie_theater" },
+    { label: "Shops", value: "store" },
+    { label: "Malls", value: "shopping_mall" },
+    { label: "Department stores", value: "department_store" },
+    { label: "Spas", value: "spa" },
+    { label: "Gyms", value: "gym" },
+    { label: "Playgrounds", value: "playground" },
+    { label: "Swimming pools", value: "swimming_pool" },
+    { label: "Golf courses", value: "gold_course" },
+    { label: "Nightclubs", value: "night_club" },
+    { label: "Churches", value: "church" },
+    { label: "Hindu temples", value: "hindu_temple" },
+    { label: "Mosques", value: "mosque" },
+    { label: "Synagogues", value: "synagogue" },
+  ];
+
+  const handleDropdownChange = (event) => {
+    setType(event.value);
+  };
+
+  return (
+    <View>
+      <ThemedText type="subtitle">Attraction Filter</ThemedText>
+      <ThemedText type="default">
+        Filter your results by type to save time scrolling!
+      </ThemedText>
+
+      <View>
+        <Dropdown
+          style={styles.background}
+          placeholder="Select attraction type"
+          data={typesList}
+          labelField="label"
+          valueField="value"
+          value={type}
+          onChange={handleDropdownChange}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  background: { backgroundColor: "white", color: "black" },
+});

--- a/components/AttractionPage.tsx
+++ b/components/AttractionPage.tsx
@@ -60,8 +60,7 @@ export default function AttractionPage({ route, navigation }) {
         <ThemedText type="default" style={styles.textBlock}>
           {attraction.editorialSummary && attraction.editorialSummary.text
             ? attraction.editorialSummary.text
-            : ""} </ThemedText>
-            <ThemedText></ThemedText>
+            : null} </ThemedText>
 
           <ThemedText style={styles.address}>Address: {attraction.formattedAddress} {attraction.nationalPhoneNumber
             ? `\n\nPhone number: ${attraction.nationalPhoneNumber}`
@@ -69,7 +68,7 @@ export default function AttractionPage({ route, navigation }) {
           {attraction.regularOpeningHours
             ? (<ThemedText>Opening hours:{'\n\n'}{attraction.regularOpeningHours.weekdayDescriptions.join("\n")}</ThemedText>): null}
        <View>
-<ThemedText>{accessibilityFeatures.length? (<ThemedText>{`\nWheelchair facilities: ${accessibilityFeatures.join(", ")}`}</ThemedText> ): null}</ThemedText>
+{accessibilityFeatures.length? (<ThemedText>{`\nWheelchair facilities: ${accessibilityFeatures.join(", ")}`}</ThemedText> ): null}
 </View>
         {attraction.websiteUri ?(<ThemedText
           style={{ color: "blue", marginVertical:20 }}
@@ -94,7 +93,7 @@ export default function AttractionPage({ route, navigation }) {
                   </View>
                 );
               })
-            : "none available"}{" "}
+            :<ThemedText> "none available" </ThemedText>}
         </View>): null}
       </View>
     </ParallaxScrollView>

--- a/components/AttractionSearchByName.tsx
+++ b/components/AttractionSearchByName.tsx
@@ -7,26 +7,13 @@ import { ThemedText } from './ThemedText'
 import { getAttractions } from '@/app/api'
 
 
-export default function AttractionSearchByName ({setAttractions, setIsSearchTerm})  {
+export default function AttractionSearchByName ({setAttractions, setIsSearchTerm, text, setText, searchTerm, setSearchTerm, gobbledigook, setGobbledigook})  {
 
 const { cityName, setCityName } = useContext(AppContext);
-const [text, setText] = useState("")
-const[searchTerm, setSearchTerm] = useState("")
-const [gobbledigook, setGobbledigook] = useState(false)
 
 useEffect(()=>{
   if(searchTerm){
-        setGobbledigook(false)
         setIsSearchTerm(true)
-        getCity(cityName).then(({city})=>{
-          console.log(city.city_rectangle, 'city_rectangle')
-           return getSearchPlaces(city.city_rectangle, searchTerm)
-        }).then(({data})=>{
-            console.log(data)
-            if(data.places){
-            setAttractions(data.places)}
-else { setGobbledigook(true)}
-        })
     }
     else{
       setIsSearchTerm(false)
@@ -40,8 +27,6 @@ useEffect(()=>{
     setSearchTerm("")
   }
 }, [text])
-
-
 
 useEffect(()=>{
 if(gobbledigook){

--- a/components/AttractionsList.tsx
+++ b/components/AttractionsList.tsx
@@ -1,18 +1,44 @@
 import { Text, View, FlatList, Image, ScrollView, StyleSheet } from 'react-native';
-import { useEffect } from 'react';
+import { useEffect , useState} from 'react';
 import { ThemedText } from './ThemedText';
 import AttractionCard from './AttractionCard';
 
-export default function AttractionsList({navigation, cityName, attractions}){
+
+export default function AttractionsList({navigation, cityName, attractions, accessibleOnly}){
+
+const [wheelchairAccessibleAttractions, setWheelChairAccessibleAttractions] = useState([])
+
+    useEffect(() => {
+          setWheelChairAccessibleAttractions(attractions.filter((attraction) => {
+              return (
+                attraction.accessibilityOptions &&
+                attraction.accessibilityOptions.wheelchairAccessibleEntrance ===
+                  true &&
+                attraction.accessibilityOptions.wheelchairAccessibleRestroom ===
+                  true
+              );
+            }))
+        }
+      , [attractions]);
+
+
     return (
         <View style={styles.container}>
             <ScrollView>
                 <View>
-                <ThemedText>Showing {attractions.length} attractions for {cityName}:</ThemedText>
-                    <View>{attractions.map((attraction)=>{return <View style={styles.attractionCard} key={attraction.id}>
+                <ThemedText>Showing { accessibleOnly ? wheelchairAccessibleAttractions.length : attractions.length} attractions for {cityName}:</ThemedText>
+                {/* //fix 'attraction / attractions here' */}
+{accessibleOnly? <View>{wheelchairAccessibleAttractions.map((attraction)=>{return <View style={styles.attractionCard} key={attraction.id}>
                         <AttractionCard navigation={navigation} cityName={cityName} attraction={attraction}/>
                     </View>})}
-                    </View>
+                    </View>: <View>{attractions.map((attraction)=>{return <View style={styles.attractionCard} key={attraction.id}>
+                        <AttractionCard navigation={navigation} cityName={cityName} attraction={attraction}/>
+                    </View>})}
+                    </View>}
+
+                    
+
+
                 </View>
             </ScrollView>
         </View>

--- a/components/SearchPage.tsx
+++ b/components/SearchPage.tsx
@@ -6,74 +6,120 @@ import { ThemedView } from "@/components/ThemedView";
 import CityDropdown from "@/components/CityDropdown";
 import AttractionsList from "@/components/AttractionsList";
 import { useContext, useState, useEffect } from "react";
-import { getAttractions, getCities, getCity } from "@/app/api";
+import {
+  getAttractions,
+  getAttractionsWithType,
+  getCities,
+  getCity,
+} from "@/app/api";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { AppContext } from "@/app/AppContext";
 import { checkIfConfigIsValid } from "react-native-reanimated/lib/typescript/reanimated2/animation/springUtils";
 import AttractionSearchByName from "./AttractionSearchByName";
+import AttractionFilter from "./AttractionFilter";
+import { getSearchPlaces } from "@/app/api";
 
 export default function SearchPage({ navigation }) {
   const { cityName, setCityName } = useContext(AppContext);
+  const [gobbledigook, setGobbledigook] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
   const [attractions, setAttractions] = useState([]);
   const [attractionsListIsLoading, setAttractionsListIsLoading] =
     useState(true);
   const [accessibleOnly, setAccessibleOnly] = useState(false);
-  const [fullCityList, setFullCityList] = useState([]);
-  const[isSearchTerm, setIsSearchTerm] = useState(false)
+  const [isSearchTerm, setIsSearchTerm] = useState(false);
+  const [text, setText] = useState("");
+  const [city, setCity] = useState({
+    city_name: "London",
+    city_latitude: 51.5072,
+    city_longitude: -0.1275,
+    city_radius: 12000,
+    city_rectangle: {
+      low: {
+        latitude: "51.286760",
+        longitude: "-0.510375",
+      },
+      high: {
+        latitude: "51.691874",
+        longitude: "0.334015",
+      },
+    },
+  });
+  const [type, setType] = useState("All");
 
   useEffect(() => {
-    if(!isSearchTerm){
-    setAttractionsListIsLoading(true);
-    setAccessibleOnly(false);
-    getCity(cityName)
-      .then((response) => {
-        console.log(response.city, 'city')
-        getAttractions(
-          response.city.city_longitude,
-          response.city.city_latitude,
-          response.city.city_radius
-        ).then((response) => {
-          setAttractionsListIsLoading(false);
-          setAttractions(response.data.places);
-          setFullCityList(response.data.places);
+    if (!isSearchTerm) {
+      setAttractionsListIsLoading(true);
+      setText("");
+      getCity(cityName)
+        .then((response) => {
+          setCity(response.city);
+          if (type === "All") {
+            getAttractions(
+              response.city.city_longitude,
+              response.city.city_latitude,
+              response.city.city_radius
+            )
+              .then((response) => {
+                setAttractionsListIsLoading(false);
+                setAttractions(response.data.places);
+              })
+              .catch((err) => {
+                console.log(err);
+              });
+          } else {
+            getAttractionsWithType(
+              response.city.city_longitude,
+              response.city.city_latitude,
+              response.city.city_radius,
+              [type]
+            )
+              .then((response) => {
+                setAttractionsListIsLoading(false);
+                setAttractions(response.data.places);
+              })
+              .catch((err) => {
+                console.log(err);
+              });
+          }
+        })
+        .catch((err) => {
+          console.log(err);
         });
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-}
-}, [cityName]);
-
-
-useEffect(()=>{
-  if(!isSearchTerm){ 
-    setAccessibleOnly(false);
-    setAttractions(fullCityList)
-  }
-}, [isSearchTerm])
-
-  useEffect(() => {
-    if (accessibleOnly) {
-      setAttractions((attractions) => {
-        const copyAttractions = [...attractions];
-        const filteredAttractions = copyAttractions.filter((attraction) => {
-          return (
-            attraction.accessibilityOptions &&
-            attraction.accessibilityOptions.wheelchairAccessibleEntrance ===
-              true &&
-            attraction.accessibilityOptions.wheelchairAccessibleRestroom ===
-              true
-          );
-        });
-        return filteredAttractions;
-      });
     } else {
-      setAttractions(fullCityList);
+      setAttractionsListIsLoading(true);
+      setGobbledigook(false);
+      getCity(cityName)
+        .then(({ city }) => {
+          return getSearchPlaces(city.city_rectangle, searchTerm);
+        })
+        .then(({ data }) => {
+          setAttractionsListIsLoading(false);
+          if (data.places) {
+            setAttractions(data.places);
+          } else {
+            setGobbledigook(true);
+          }
+        });
     }
-  }, [accessibleOnly]);
-  
-return (
+  }, [cityName, type, isSearchTerm]);
+
+  useEffect(() => {
+    if (isSearchTerm) {
+      setType("All");
+    }
+  }, [isSearchTerm]);
+
+  useEffect(() => {
+    setText("");
+  }, [type]);
+
+  // useEffect(()=>{
+  // setText("")
+  // }, [cityName])
+
+  return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: "#D0D0D0", dark: "#353636" }}
       headerImage={
@@ -81,20 +127,32 @@ return (
       }
     >
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">
-         Welcome!</ThemedText>
-         <ThemedText type="subtitle">
-        Select your city from the dropdown menu and get ready to start planning your next adventure.
+        <ThemedText type="title">Welcome!</ThemedText>
+        <ThemedText type="subtitle">
+          Select your city from the dropdown menu and get ready to start
+          planning your next adventure.
         </ThemedText>
       </ThemedView>
       <CityDropdown navigation={navigation} />
-     <AttractionSearchByName setAttractions={setAttractions} setIsSearchTerm={setIsSearchTerm}/>
+      <AttractionSearchByName
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        gobbledigook={gobbledigook}
+        setGobbledigook={setGobbledigook}
+        setAttractions={setAttractions}
+        setIsSearchTerm={setIsSearchTerm}
+        text={text}
+        setText={setText}
+      />
+
+      <AttractionFilter type={type} setType={setType} />
       <View style={styles.accessibilityCheckboxContainer}>
         <CheckBox
           value={accessibleOnly}
           onValueChange={setAccessibleOnly}
           style={styles.checkbox}
         />
+
         <Text style={styles.label}>
           Wheelchair-accessible attractions only (has a wheelchair-accessible
           entrance and toilet)
@@ -107,6 +165,7 @@ return (
           cityName={cityName}
           attractions={attractions}
           navigation={navigation}
+          accessibleOnly={accessibleOnly}
         />
       )}
     </ParallaxScrollView>


### PR DESCRIPTION
Enables user to filter attractions on home page by type. Works with wheelchair accessibility toggle. When user searches for attraction by name, the type is ignored. But type persists when user changes city.